### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,35 @@ matrix:
       dist: trusty
     - perl: "5.12"
       dist: trusty
+    #powerjobs
+    - perl: "5.28"
+      dist: xenial
+      arch: ppc64le
+    - perl: "5.26"
+      dist: xenial
+      arch: ppc64le
+    - perl: "5.24"
+      dist: xenial
+      arch: ppc64le
+    - perl: "5.22"
+      dist: xenial
+      arch: ppc64le
+    - perl: "5.20"
+      dist: trusty
+      arch: ppc64le
+    - perl: "5.18"
+      dist: trusty
+      arch: ppc64le
+    - perl: "5.16"
+      dist: trusty
+      arch: ppc64le
+    - perl: "5.14"
+      dist: trusty
+      arch: ppc64le
+    - perl: "5.12"
+      dist: trusty
+      arch: ppc64le
+    
 install:
   - cpanm --local-lib=~/perl5 local::lib
   - cpanm --local-lib=~/perl5 --quiet --notest --skip-satisfied Devel::Cover


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
